### PR TITLE
Doom Peninsula Overhaul

### DIFF
--- a/maps/submaps/surface_submaps/wilderness/DoomP.dmm
+++ b/maps/submaps/surface_submaps/wilderness/DoomP.dmm
@@ -64,8 +64,9 @@
 /turf/simulated/floor/outdoors/grass/sif/forest,
 /area/submap/DoomP)
 "ar" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/outdoors/grass/sif/forest,
+/obj/structure/closet/l3closet/scientist,
+/obj/effect/floor_decal/corner/orange/diagonal,
+/turf/simulated/floor/tiled/asteroid_steel,
 /area/submap/DoomP)
 "as" = (
 /obj/machinery/porta_turret/poi{
@@ -192,6 +193,7 @@
 /area/submap/DoomP)
 "aK" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
+/obj/item/stolenpackage,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/submap/DoomP)
 "aL" = (
@@ -222,6 +224,9 @@
 "aQ" = (
 /obj/machinery/vending/snack,
 /obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/machinery/light/small{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -353,18 +358,21 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/submap/DoomP)
 "bm" = (
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/techfloor,
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/machinery/light/small,
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/turf/simulated/floor/tiled/asteroid_steel,
 /area/submap/DoomP)
 "bn" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/syndie_kit/spy,
+/obj/item/weapon/storage/box/handcuffs,
 /turf/simulated/floor/tiled/techfloor,
 /area/submap/DoomP)
 "bo" = (
 /obj/structure/table/rack,
-/obj/item/weapon/storage/box/smokes,
-/obj/item/weapon/storage/box/handcuffs,
+/obj/item/weapon/rig/combat/empty,
+/obj/item/weapon/rig/combat/empty,
 /turf/simulated/floor/tiled/techfloor,
 /area/submap/DoomP)
 "bq" = (
@@ -377,16 +385,21 @@
 /obj/item/clothing/shoes/boots/tactical,
 /obj/item/clothing/shoes/boots/tactical,
 /obj/item/clothing/head/helmet/tactical,
+/obj/item/clothing/shoes/magboots/adv,
+/obj/item/clothing/shoes/magboots/adv,
+/obj/item/clothing/suit/storage/vest/heavy/merc,
 /turf/simulated/floor/tiled/techfloor,
 /area/submap/DoomP)
 "br" = (
 /obj/structure/table/rack,
-/obj/random/energy,
 /obj/item/weapon/cell/device/weapon,
 /obj/item/weapon/cell/device/weapon,
 /obj/item/weapon/cell/device/weapon,
 /obj/item/weapon/cell/device/weapon,
 /obj/random/energy,
+/obj/random/energy,
+/obj/random/energy/highend,
+/obj/random/energy/highend,
 /turf/simulated/floor/tiled/techfloor,
 /area/submap/DoomP)
 "bs" = (
@@ -397,6 +410,8 @@
 /obj/item/weapon/gun/projectile/contender,
 /obj/item/ammo_magazine/s357,
 /obj/item/ammo_magazine/s357,
+/obj/random/projectile/random,
+/obj/random/projectile/random,
 /turf/simulated/floor/tiled/techfloor,
 /area/submap/DoomP)
 "bt" = (
@@ -409,19 +424,14 @@
 /turf/simulated/floor/tiled/white,
 /area/submap/DoomP)
 "bu" = (
-/obj/structure/table/standard,
-/obj/effect/floor_decal/corner/lime{
-	dir = 5
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/asteroid_steel,
 /area/submap/DoomP)
 "bv" = (
-/obj/structure/bed,
-/obj/item/weapon/bedsheet,
-/obj/effect/floor_decal/corner/lime{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/white,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
 /area/submap/DoomP)
 "bw" = (
 /obj/structure/table/standard,
@@ -437,36 +447,29 @@
 /turf/simulated/floor/tiled,
 /area/submap/DoomP)
 "by" = (
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/submap/DoomP)
 "bz" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
+/obj/structure/table/standard,
+/obj/item/weapon/storage/box/metalfoam,
+/obj/item/weapon/storage/box/smokes,
+/turf/simulated/floor/tiled/techfloor,
 /area/submap/DoomP)
 "bA" = (
-/obj/structure/sink{
-	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
+/obj/machinery/portable_atmospherics/canister/phoron,
+/obj/effect/floor_decal/borderfloorwhite,
+/turf/simulated/floor/tiled/asteroid_steel,
 /area/submap/DoomP)
 "bB" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/techfloor,
 /area/submap/DoomP)
 "bC" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/lime/full,
-/turf/simulated/floor/tiled/white,
+/mob/living/simple_mob/humanoid/merc/ranged/ionrifle,
+/turf/simulated/floor/tiled/asteroid_steel,
 /area/submap/DoomP)
 "bD" = (
 /obj/effect/floor_decal/corner/lime{
@@ -475,60 +478,45 @@
 /turf/simulated/floor/tiled/white,
 /area/submap/DoomP)
 "bE" = (
+/obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/lime{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/plating,
 /area/submap/DoomP)
 "bF" = (
 /obj/machinery/shower{
 	dir = 1
 	},
 /obj/structure/curtain/open/shower,
+/obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/submap/DoomP)
 "bG" = (
 /obj/structure/toilet{
 	dir = 1
 	},
+/obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/submap/DoomP)
 "bH" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/window/reinforced{
+/obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/asteroid_steel,
 /area/submap/DoomP)
 "bI" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating,
 /area/submap/DoomP)
 "bJ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
+/obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/sink{
+	pixel_y = 16
 	},
-/obj/machinery/door/firedoor/border_only,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/corner/white/diagonal,
+/turf/simulated/floor/tiled/white,
 /area/submap/DoomP)
 "bK" = (
 /obj/structure/lattice,
@@ -561,12 +549,445 @@
 /turf/simulated/floor/tiled/white,
 /area/submap/DoomP)
 "bP" = (
-/obj/random/junk,
-/turf/simulated/floor/outdoors/rocks,
+/obj/structure/table/standard,
+/obj/item/weapon/paper,
+/obj/item/weapon/pen,
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/asteroid_steel,
 /area/submap/DoomP)
 "bQ" = (
-/obj/random/junk,
-/turf/simulated/floor/outdoors/grass/sif/forest,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/DoomP)
+"fm" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/DoomP)
+"gA" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/effect/floor_decal/borderfloorwhite,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/DoomP)
+"jD" = (
+/obj/structure/bed,
+/obj/item/weapon/bedsheet,
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 8
+	},
+/obj/item/toy/plushie/borgplushie/drakiesec,
+/turf/simulated/floor/tiled/white,
+/area/submap/DoomP)
+"kp" = (
+/obj/random/mob/merc/all,
+/turf/simulated/floor/tiled/white,
+/area/submap/DoomP)
+"kI" = (
+/obj/effect/floor_decal/borderfloorwhite/corner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/DoomP)
+"kS" = (
+/obj/machinery/power/emitter{
+	anchored = 1;
+	dir = 1;
+	state = 2
+	},
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/DoomP)
+"lc" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled/red,
+/area/submap/DoomP)
+"nX" = (
+/obj/structure/table/standard,
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 1
+	},
+/obj/random/thermalponcho,
+/turf/simulated/floor/tiled/white,
+/area/submap/DoomP)
+"og" = (
+/obj/machinery/auto_cloner,
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8;
+	external_pressure_bound = 0;
+	external_pressure_bound_default = 0;
+	icon_state = "map_vent_in";
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	internal_pressure_bound_default = 4000;
+	pressure_checks = 2;
+	pressure_checks_default = 2;
+	pump_direction = 0;
+	use_power = 1
+	},
+/turf/simulated/floor/airless,
+/area/template_noop)
+"px" = (
+/obj/structure/table/standard,
+/obj/item/clothing/head/welding,
+/obj/item/weapon/weldingtool,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 10
+	},
+/obj/item/weapon/flame/lighter/random,
+/obj/item/weapon/storage/box/monkeycubes,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/DoomP)
+"pB" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/machinery/atmospherics/binary/pump,
+/obj/random/mob/merc/all,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/DoomP)
+"pL" = (
+/turf/simulated/wall{
+	can_open = 1
+	},
+/area/submap/DoomP)
+"rx" = (
+/obj/machinery/power/terminal{
+	dir = 1;
+	icon_state = "term"
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/submap/DoomP)
+"rJ" = (
+/obj/effect/floor_decal/corner/lime/full{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/submap/DoomP)
+"vd" = (
+/obj/effect/floor_decal/corner/lime/full{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/submap/DoomP)
+"vq" = (
+/obj/structure/table/rack,
+/obj/item/weapon/archaeological_find,
+/obj/item/weapon/archaeological_find,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/item/weapon/gun/energy/captain/xenoarch,
+/obj/item/weapon/archaeological_find,
+/obj/item/weapon/archaeological_find,
+/obj/item/weapon/gun/energy/captain/xenoarch,
+/obj/item/weapon/gun/energy/captain/xenoarch,
+/obj/item/weapon/cell/device/weapon/recharge/alien/omni,
+/obj/item/weapon/gun/energy/captain/xenoarch,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/DoomP)
+"vu" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/DoomP)
+"xE" = (
+/obj/structure/lattice,
+/turf/simulated/floor/water/deep,
+/area/submap/DoomP)
+"yp" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/submap/DoomP)
+"yF" = (
+/obj/structure/bed,
+/obj/item/weapon/bedsheet,
+/obj/effect/floor_decal/corner/lime/full,
+/obj/item/toy/plushie/basset,
+/turf/simulated/floor/tiled/white,
+/area/submap/DoomP)
+"BW" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled/red,
+/area/submap/DoomP)
+"Cn" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/submap/DoomP)
+"Db" = (
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower{
+	dir = 4;
+	pixel_x = 5
+	},
+/turf/simulated/floor/plating,
+/area/submap/DoomP)
+"FE" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/DoomP)
+"Hz" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/DoomP)
+"Jj" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/light/small,
+/obj/machinery/artifact,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/DoomP)
+"Jq" = (
+/obj/effect/floor_decal/corner/lime{
+	dir = 10
+	},
+/obj/random/mob/merc/all,
+/turf/simulated/floor/tiled/white,
+/area/submap/DoomP)
+"JU" = (
+/obj/effect/floor_decal/corner/orange/diagonal,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/DoomP)
+"LU" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 5
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 6
+	},
+/obj/machinery/computer/general_air_control,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/DoomP)
+"LW" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/white/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/submap/DoomP)
+"Mc" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/submap/DoomP)
+"MQ" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/DoomP)
+"Nl" = (
+/obj/structure/table/standard,
+/obj/machinery/cell_charger,
+/obj/item/weapon/tool/screwdriver{
+	pixel_y = 15
+	},
+/obj/item/weapon/melee/baton/loaded,
+/obj/item/device/multitool,
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/item/weapon/tool/crowbar,
+/obj/item/clothing/gloves/sterile/latex,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/DoomP)
+"OV" = (
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/submap/DoomP)
+"Pk" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/submap/DoomP)
+"PU" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/DoomP)
+"Ra" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/submap/DoomP)
+"Re" = (
+/obj/effect/floor_decal/borderfloorwhite/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/DoomP)
+"TX" = (
+/obj/structure/table/standard,
+/obj/item/weapon/reagent_containers/food/snacks/pancakes/berry,
+/obj/effect/floor_decal/corner/lime/border,
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/white,
+/area/submap/DoomP)
+"Ul" = (
+/obj/structure/table/rack,
+/obj/item/weapon/archaeological_find,
+/obj/item/weapon/archaeological_find,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/item/capture_crystal,
+/obj/item/stack/material/morphium{
+	amount = "5"
+	},
+/obj/item/weapon/circuitboard/mecha/imperion/main,
+/obj/item/weapon/circuitboard/mecha/imperion/targeting,
+/obj/item/weapon/archaeological_find,
+/obj/item/weapon/cell/device/weapon/recharge/alien/omni,
+/obj/item/weapon/archaeological_find,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/DoomP)
+"VA" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/DoomP)
+"VC" = (
+/obj/structure/bed/chair,
+/mob/living/simple_mob/humanoid/merc/ranged/deagle,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/DoomP)
+"VV" = (
+/obj/structure/bed,
+/obj/item/weapon/bedsheet,
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 8
+	},
+/obj/item/toy/plushie/moth,
+/turf/simulated/floor/tiled/white,
+/area/submap/DoomP)
+"Wt" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/mob/living/simple_mob/mechanical/mecha/ripley/pirate/last_stand_merc{
+	faction = "syndicate"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/DoomP)
+"Ww" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 6
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/DoomP)
+"Wy" = (
+/obj/random/mob/merc/all,
+/obj/effect/floor_decal/corner/orange/diagonal,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/DoomP)
+"WH" = (
+/obj/machinery/door/airlock/hatch,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/DoomP)
+"Xj" = (
+/obj/structure/table/standard,
+/obj/item/stolenpackage,
+/turf/simulated/floor/tiled,
+/area/submap/DoomP)
+"XV" = (
+/obj/structure/table/darkglass,
+/obj/item/weapon/gun/energy/imperial,
+/obj/item/clothing/suit/armor/swat/officer,
+/obj/item/clothing/glasses/graviton/medgravpatch,
+/obj/item/clothing/head/psy_crown/wrath,
+/obj/item/toy/plushie/carp/nebula,
+/turf/simulated/floor/plating,
+/area/submap/DoomP)
+"Yt" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 9
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/DoomP)
+"YT" = (
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/random/mob/merc/armored,
+/turf/simulated/floor/tiled/red,
+/area/submap/DoomP)
+"Zl" = (
+/obj/machinery/door/airlock/external/bolted,
+/turf/simulated/floor/plating,
 /area/submap/DoomP)
 
 (1,1,1) = {"
@@ -1775,16 +2196,16 @@ af
 af
 af
 af
-af
-af
-af
 as
 af
 af
 as
 ak
 ak
+as
 ak
+ak
+as
 ak
 ak
 ak
@@ -1837,16 +2258,16 @@ af
 ac
 ac
 ac
-ac
-ac
-ac
 aL
 af
 af
 aX
 af
 af
+aX
 ak
+ak
+aX
 ak
 ak
 ak
@@ -1896,9 +2317,6 @@ af
 af
 af
 ac
-ac
-ad
-ad
 ad
 at
 at
@@ -1909,8 +2327,11 @@ at
 at
 at
 at
-af
-ak
+at
+at
+at
+at
+at
 ak
 ak
 ak
@@ -1959,20 +2380,20 @@ af
 ac
 ac
 ad
-ad
-ad
-ad
 at
 ax
 aM
 aY
 bd
-bj
-bl
-bl
 at
-af
-ak
+bz
+bo
+bq
+br
+at
+Hz
+vq
+at
 ak
 ak
 ak
@@ -2020,23 +2441,23 @@ af
 ac
 ac
 ad
-ad
-ad
-ad
 as
 at
 ay
 aN
 aN
 be
-at
-bm
+bj
 bl
+bL
+bl
+bB
 at
-af
-af
-ak
-ak
+Wt
+Jj
+at
+xE
+as
 ak
 ak
 ak
@@ -2083,20 +2504,20 @@ ac
 ad
 ad
 ad
-ad
-ad
-ad
 at
 aA
 aO
-aN
+Xj
 be
 at
 bn
-bB
+bo
+bq
+bs
 at
-af
-af
+Hz
+Ul
+at
 af
 af
 ak
@@ -2145,20 +2566,20 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
 at
 ay
 aN
 aN
 bf
 at
-bo
-bl
 at
-aL
-as
+at
+at
+at
+at
+bj
+at
+at
 af
 af
 af
@@ -2206,21 +2627,21 @@ ac
 ad
 ad
 ad
-ad
-ad
-ad
 as
 at
 aB
-aN
+aO
 bg
 be
 at
-bq
-bL
+FE
+bH
+bH
+fm
+bH
+bH
+px
 at
-ac
-af
 af
 af
 af
@@ -2269,20 +2690,20 @@ aq
 ad
 ad
 ad
-ad
-ad
-ad
 at
 ay
 aN
 aN
 bx
 at
-bq
-bB
-at
+LU
+pB
+vu
+kI
+bQ
+VC
 bP
-ac
+at
 af
 af
 af
@@ -2330,9 +2751,6 @@ ad
 ad
 ad
 ad
-ad
-ad
-ar
 at
 at
 az
@@ -2340,11 +2758,14 @@ aP
 aP
 bM
 at
-br
-bl
+yp
+Ra
+lc
+VA
+bQ
+bQ
+Nl
 at
-ad
-ac
 af
 af
 af
@@ -2392,9 +2813,6 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
 au
 at
 aC
@@ -2402,13 +2820,16 @@ aQ
 aZ
 aP
 at
-bs
-bl
+og
+Zl
+YT
+bQ
+kS
+bQ
+gA
 at
-ad
-ac
-af
-af
+aX
+as
 af
 af
 af
@@ -2454,9 +2875,6 @@ ad
 ad
 aq
 ad
-ad
-ad
-ad
 av
 at
 at
@@ -2464,11 +2882,14 @@ at
 at
 bh
 at
+Pk
+Ra
+BW
+VA
+bQ
+bQ
+bA
 at
-at
-at
-ad
-ac
 af
 af
 af
@@ -2516,9 +2937,6 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
 av
 aw
 aD
@@ -2526,11 +2944,14 @@ aP
 ba
 aP
 at
-bt
+Yt
+bH
+bH
+Re
 bC
+bQ
+bm
 at
-ad
-ac
 ac
 af
 af
@@ -2578,9 +2999,6 @@ ac
 ad
 ad
 ad
-ad
-ad
-ad
 av
 at
 at
@@ -2588,11 +3006,14 @@ at
 at
 bN
 at
+MQ
 bu
-bD
+bu
+PU
+bu
+bu
+Ww
 at
-bK
-as
 ac
 ac
 af
@@ -2640,9 +3061,6 @@ ac
 ad
 ad
 ad
-ad
-ad
-ad
 au
 at
 aE
@@ -2650,11 +3068,14 @@ aR
 at
 bi
 at
-bv
-bD
-bH
-ad
-ad
+at
+WH
+at
+at
+at
+at
+at
+at
 ad
 ac
 af
@@ -2702,22 +3123,22 @@ ac
 ad
 ah
 ad
-ad
-ad
-ar
 at
 at
 aF
-aS
+rx
 at
 aP
 at
-bw
-bD
+ar
+JU
+JU
+as
+at
 bI
+XV
+at
 ad
-ad
-bQ
 ac
 af
 af
@@ -2765,22 +3186,22 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
 at
 aF
 aS
 at
 aP
-at
+bh
+JU
+Wy
+JU
 bv
-bD
-bI
-ad
-ad
-ad
-ac
+at
+pL
+at
+at
+bK
+as
 af
 af
 af
@@ -2826,9 +3247,6 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
 as
 at
 aF
@@ -2836,11 +3254,14 @@ aS
 at
 aP
 at
-bO
-bD
-bI
-ad
-ad
+JU
+JU
+JU
+as
+at
+bJ
+bF
+at
 ad
 ac
 af
@@ -2889,20 +3310,20 @@ ad
 ad
 ac
 ad
-ad
-ad
-ad
 at
 aG
 aT
 at
 aP
-bk
-by
+at
+Db
 bE
-bJ
-ad
-ad
+Db
+at
+at
+LW
+bG
+at
 ad
 ac
 af
@@ -2951,20 +3372,20 @@ ac
 am
 ac
 ac
-ad
-ad
-ad
 at
 aH
 aU
 bb
 aP
 at
+at
+at
+at
+at
+at
 bk
 at
 at
-bK
-as
 ac
 ac
 af
@@ -3012,9 +3433,6 @@ ac
 af
 af
 af
-ac
-ac
-ad
 as
 at
 aI
@@ -3022,11 +3440,14 @@ aV
 bc
 bi
 at
-bz
-bF
+bt
+Mc
+jD
+OV
+VV
+OV
+yF
 at
-ac
-ac
 ac
 af
 af
@@ -3075,20 +3496,20 @@ af
 af
 af
 af
-ac
-ac
-ad
 at
 aJ
 aW
 at
 aP
 at
-bk
+nX
+Jq
+bw
+bD
+bO
+kp
+TX
 at
-at
-bP
-af
 af
 af
 af
@@ -3137,22 +3558,22 @@ af
 af
 af
 af
-af
-ac
-ac
 at
 aK
 aV
 at
 aP
+bk
+rJ
+by
+by
+by
+by
+by
+vd
 at
-bA
-bG
-at
-af
-af
-af
-af
+aX
+as
 af
 af
 af
@@ -3199,9 +3620,6 @@ af
 af
 af
 af
-af
-af
-af
 at
 at
 at
@@ -3209,10 +3627,13 @@ at
 at
 at
 at
+Pk
+Cn
+Cn
+Cn
+Ra
 at
 at
-af
-af
 af
 af
 af
@@ -3263,16 +3684,16 @@ af
 af
 af
 af
-af
-af
-af
 aX
 af
 af
 aX
 af
 af
+aX
 af
+af
+aX
 af
 af
 af
@@ -3325,16 +3746,16 @@ af
 af
 af
 af
-af
-af
-af
 as
 af
 af
 as
 af
 af
+as
 af
+af
+as
 af
 af
 af

--- a/maps/submaps/surface_submaps/wilderness/Manor1.dmm
+++ b/maps/submaps/surface_submaps/wilderness/Manor1.dmm
@@ -307,9 +307,7 @@
 /area/submap/Manor1)
 "bi" = (
 /obj/effect/decal/cleanable/cobweb,
-/turf/simulated/floor/holofloor/wood{
-	icon_state = "wood_broken0"
-	},
+/turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "bj" = (
 /obj/effect/decal/cleanable/cobweb,
@@ -396,6 +394,11 @@
 /obj/item/clothing/suit/storage/hooded/wintercoat/kilanocoat,
 /obj/item/clothing/head/hood/winter,
 /obj/item/clothing/shoes/boots/winter/climbing,
+/obj/item/ammo_magazine/m75,
+/obj/item/ammo_magazine/m75,
+/obj/item/ammo_magazine/m75,
+/obj/item/ammo_magazine/m75,
+/obj/item/ammo_magazine/m75,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "bz" = (
@@ -641,6 +644,7 @@
 /obj/item/stack/material/tritium{
 	amount = 20
 	},
+/obj/item/weapon/cell/super,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "co" = (
@@ -1237,6 +1241,9 @@
 /obj/structure/loot_pile/surface/bones,
 /obj/effect/spider/stickyweb,
 /obj/item/weapon/gun/projectile/gyropistol,
+/obj/item/ammo_magazine/m75,
+/obj/item/ammo_magazine/m75,
+/obj/item/ammo_magazine/m75,
 /turf/simulated/floor/carpet/purcarpet,
 /area/submap/Manor1)
 "GM" = (


### PR DESCRIPTION
Expanded the merc base upon the peninsula, giving it a purpose of being a research base. Added some more goodies, and more foes. Turrets might be a tad overboard.

Oh and added 8? gyropistol clips, and a cell battery to the manor. Cell battery is in the storage room, and 3 clips with the gyropistol, while 5 are in a closest in another room. Note gyropistol cannot be made. Those 8 clips are all you're getting.