### PR TITLE
explicit types, no timer needed if they don't match

### DIFF
--- a/modular_chomp/code/modules/mob/living/simple_mob/subtypes/humanoid/eclipse/eclipse.dm
+++ b/modular_chomp/code/modules/mob/living/simple_mob/subtypes/humanoid/eclipse/eclipse.dm
@@ -855,15 +855,13 @@
 /mob/living/simple_mob/humanoid/eclipse/solar/plant/do_special_attack(atom/A)
 	visible_message(span_warning("\The [src]'s vines spread out!"))
 	Beam(A, icon_state = "vine", time = 3 SECONDS, maxdistance = INFINITY)
-	if(isliving(A))
-		if(iscarbon(A))
-			addtimer(CALLBACK(src, PROC_REF(itemyoink), A), 3 SECONDS, TIMER_DELETE_ME)
+	if(ishuman(A))
+		addtimer(CALLBACK(src, PROC_REF(itemyoink), A), 3 SECONDS, TIMER_DELETE_ME)
 
 
-/mob/living/simple_mob/humanoid/eclipse/proc/itemyoink(atom/A)
-	if(!A)
+/mob/living/simple_mob/humanoid/eclipse/proc/itemyoink(mob/living/carbon/human/H)
+	if(!H)
 		return
-	var/mob/living/carbon/human/H = A
 	var/obj/item/I = H.get_active_hand()
 	H.drop_item()
 	if(I)
@@ -888,14 +886,13 @@
 
 /mob/living/simple_mob/humanoid/eclipse/lunar/experimenter/do_special_attack(atom/A)
 	visible_message(span_danger("The [src]'s gauntlet glows silver!"))
-	addtimer(CALLBACK(src, PROC_REF(gravity_pull), A), 3 SECOND, TIMER_DELETE_ME)
+	if(isliving(A))
+		addtimer(CALLBACK(src, PROC_REF(gravity_pull), A), 3 SECOND, TIMER_DELETE_ME)
 
-/mob/living/simple_mob/humanoid/eclipse/proc/gravity_pull(atom/A)
-	if(!A)
+/mob/living/simple_mob/humanoid/eclipse/proc/gravity_pull(mob/living/L)
+	if(!L)
 		return
-	var/D = src
-	var/mob/living/carbon/human/H = A
-	H.throw_at(D, 2, 4) // Just yoinked.
+	L.throw_at(src, 2, 4) // Just yoinked.
 
 //The Precursor intative big folks
 /mob/living/simple_mob/humanoid/eclipse/lunar/titanhunter //lunar melee unit

--- a/modular_chomp/code/modules/mob/living/simple_mob/subtypes/humanoid/eclipse/heads.dm
+++ b/modular_chomp/code/modules/mob/living/simple_mob/subtypes/humanoid/eclipse/heads.dm
@@ -172,10 +172,11 @@
 
 /mob/living/simple_mob/humanoid/eclipse/head/scientist/do_special_attack(atom/A)
 	if(vore_fullness == 1)
-
+	// FIX THAT
 	else if(vore_fullness > 1)
-
+	// FIX THAT
 	else
+	// FIX THAT
 
 
 /mob/living/simple_mob/mechanical/hivebot/swarm/eclipse


### PR DESCRIPTION
we should only add the timer if the target subtype matches, else we have a useless timer running, so we first typecheck, then pass it in the head.

Marked an empty if esle section